### PR TITLE
Update 2: proposition 2

### DIFF
--- a/mods.js
+++ b/mods.js
@@ -855,9 +855,9 @@ $(document).ready(function() {
 var kd = false;
 $(document).keydown(function(e) {
 	//Stats Shortcut
-	if (e.keyCode == 192) {
-		//e.preventDefault();
+	if (e.keyCode == 9) {
 		if (kd == false && document.getElementById("overlays").style.display == 'none') {
+                        e.preventDefault();
 			kd = true;
 			document.getElementById("overlays").style.display = "block";
 			document.getElementById("overlays").style.backgroundColor = "rgba(0,0,0,0)";
@@ -886,8 +886,8 @@ $(document).keydown(function(e) {
 	}
 });
 $(document).keyup(function(e) {
-	if (e.keyCode == 192) {
-		//e.preventDefault();
+	if (e.keyCode == 9) {
+		e.preventDefault(); //doesn't break tab
 		if (kd == true) {
 			kd = false;
 			document.getElementById("overlays").style.display = "none";


### PR DESCRIPTION
setting show by default, instructions removed(if you got the mod, you know enough bout the game)
fps toggled with the ctrl+1(to prevent conflict while typing)
Tab should work when not playing