### PR TITLE
On chrome only webstore link shows

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,16 +78,13 @@
 					</span></div>
 				<div><div class="col-sm-6">
 					<!--Button to install -->
-					<h3><a id="ScriptButton" target="_self" href="//agariomods.com/pull.html">
-						CLICK TO INSTALL SCRIPT</a></h3>
-					<div style="font-size: 10px; text-align: right">*Disable Adblock before installing!<br>
-						*Approved by the r/Agario Moderation Team!</div>
+                                        <script>navigator.userAgent.match("Chrome")?document.write('<a href="https://chrome.google.com/webstore/detail/agariomods-evergreen-scri/nhjgdbihpkphlammdaeicdemggagfbdo" target="_blank"><img src="chromebannerhuge.png"/></a><br>'):document.write('<h3><a id="ScriptButton" target="_self" href="//agariomods.com/pull.html">CLICK TO INSTALL SCRIPT</a></h3>')</script>
+<br><div style="font-size: 10px; text-align: right">*Disable Adblock before installing!<br>
+						*Approved by the r/Agario Moderation Team!<script>if(navigator.userAgent.match("Chrome"))document.write('<br><a>Alternative Installation Method</a>');</script></div>
 					</div></div></div></div>
 			<div style="padding-left: 30px; padding-bottom: 5px; padding-top: 5px; font-size: 12px !important">
-				To run this script you require either tampermonkey or greasemonkey installed in your browser first.<br>
+				<script>navigator.userAgent.match("Chrome")||document.write("To run this script you require greasemonkey installed in your browser first.<br>");</script>
 				This is an evergreen script, as in, it automatically updates when changes are available so once installed doesn't need reinstalling ever. :)</div></section>
-<br>
-<a href="https://chrome.google.com/webstore/detail/agariomods-evergreen-scri/nhjgdbihpkphlammdaeicdemggagfbdo" target="_blank"><img src="chromebannerhuge.png"/></a><br>
 <br>
 <div class="hidden-xs hidden-sm">
 <script async src="//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
@@ -125,4 +122,3 @@
 
                 </body>
         </html>
-


### PR DESCRIPTION
there's a link that says "alternative installation method"  for those kind of people
page is like it was before on non-chrome browsers